### PR TITLE
added y-u-no-hover and misaligned images

### DIFF
--- a/evil.css
+++ b/evil.css
@@ -74,3 +74,18 @@ body {
     -webkit-user-select: none;
     -moz-user-select: none;
 }
+
+/* Y U NO HOVER?! */
+a:hover {
+    display: none;
+    font-size: 0;
+}
+
+/* misaligned images */
+img[align="left"] {
+    float: right;
+}
+
+img[align="right"] {
+    float: left;
+}


### PR DESCRIPTION
hovering on `a` tags makes them disappear. Putting align"left|right" on an image makes them do the opposite.
